### PR TITLE
Removed hard dependencies on `msnodesqlv8`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,7 @@ COPY package.json ./
 COPY package-lock.json ./
 
 RUN npm install
+# install optional native TDS driver
+RUN npm install msnodesqlv8
 
 COPY . .

--- a/README.md
+++ b/README.md
@@ -543,8 +543,8 @@ Processes a MSSQL `SELECT` query row by row.
 Here is an example of how to configure `MssqlProcessor` with a native TDS driver instead of the default pure JavasScript Tedious driver.
 
 ```javascript
-const nativeDriver = await import('mssql/msnodesqlV8');
-const connection: any = {
+const nativeDriver: ITdsDriver = await import('mssql/msnodesqlV8');
+const connection: IMssqlDbConnection = {
   user: 'user',
   password: 'password',
   server: 'server',
@@ -677,8 +677,8 @@ Inserts data to MSSQL.
 Here is an example of how to configure `MssqlDestination` with a native TDS driver instead of the default pure JavasScript Tedious driver.
 
 ```javascript
-const nativeDriver = await import('mssql/msnodesqlV8');
-const connection: any = {
+const nativeDriver: ITdsDriver = await import('mssql/msnodesqlV8');
+const connection: IMssqlDbConnection = {
   user: 'user',
   password: 'password',
   server: 'server',

--- a/README.md
+++ b/README.md
@@ -535,12 +535,30 @@ Processes a MSSQL `SELECT` query row by row.
   - **server**
   - **port**
   - **database**
-- **driver**\
-    Optional [mssql][mssql-url] TDS driver such as the native [msnodesqlv8][msnodesqlv8-url] driver; defaults to the pure JavaScript [Tedious][tedious-url] driver .
+  - **driver**\
+      Optional [mssql][mssql-url] TDS driver such as the native [msnodesqlv8][msnodesqlv8-url] driver; defaults to the pure JavaScript [Tedious][tedious-url] driver .
 
-[Usage examples](tests/mssql-source.spec.ts)
+#### Usage examples
 
-Note that `msnodesqlv8` is an optional peer dependency. In previous versions of `bellboy`, a `connection.driver` `string` parameter enabled choosing between the pure Javascript Tedious driver and the native mssqlnodev8  diver. This parameter is ignored in `bellboy` >= v8.0.0.
+Here is an example of how to configure `MssqlProcessor` with a native TDS driver instead of the default pure JavasScript Tedious driver.
+
+```javascript
+const nativeDriver = await import('mssql/msnodesqlV8');
+const connection: any = {
+  user: 'user',
+  password: 'password',
+  server: 'server',
+  database: 'database',
+  driver: nativeDriver
+};
+const source = new MssqlProcessor({ connection, query: 'select * from orders' });
+```
+
+In previous versions of `bellboy`, `connection.driver` was a `string` parameter.
+
+Note that `msnodesqlv8` is an optional peer dependency: To use that package, configure an explicit dependency.
+
+[More usage examples](tests/mssql-source.spec.ts)
 
 ### DynamicProcessor <div id='dynamic-processor'/>
 
@@ -652,11 +670,27 @@ Inserts data to MSSQL.
   - **password**
   - **server**
   - **database**
-- **driver**
+  - **driver**
 
-[Usage examples](tests/mssql-destination.spec.ts)
+#### Usage examples
 
-See [MssqlProcessor](#mssql-processor) for the usage of the `driver` parameter and notes about the optional `msnodesqlv8` dependency.
+Here is an example of how to configure `MssqlDestination` with a native TDS driver instead of the default pure JavasScript Tedious driver.
+
+```javascript
+const nativeDriver = await import('mssql/msnodesqlV8');
+const connection: any = {
+  user: 'user',
+  password: 'password',
+  server: 'server',
+  database: 'database',
+  driver: nativeDriver
+};
+const sink = new MssqlDestination({ connection, table: 'orders', batchSize: 1000 });
+```
+
+See [MssqlProcessor](#mssql-processor) for additional notes about the optional `driver` parameter and the `msnodesqlv8` dependency.
+
+[More usage examples](tests/mssql-destination.spec.ts)
 
 ## Extendability
 

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ const source = new MssqlProcessor({ connection, query: 'select * from orders' })
 
 In previous versions of `bellboy`, `connection.driver` was a `string` parameter.
 
-Note that `msnodesqlv8` is an optional peer dependency: To use that package, configure an explicit dependency.
+Note that `msnodesqlv8` is an optional peer dependency: To use that driver, configure an explicit dependency on the `msnodesqlv8` package.
 
 [More usage examples](tests/mssql-source.spec.ts)
 

--- a/README.md
+++ b/README.md
@@ -300,8 +300,8 @@ Each processor in `bellboy` is a class which has a single responsibility of proc
 - [ExcelProcessor](#excel-processor) processes **XLSX** file data from the file system.
 - [JsonProcessor](#json-processor) processes **JSON** file data from the file system.
 - [DelimitedProcessor](#delimited-processor) processes files with **delimited data** from the file system.
-- [PostgresProcessor](#database-processors) processes data received from a **PostgreSQL** SELECT.
-- [MssqlProcessor](#database-processors) processes data received from a **MSSQL** SELECT.
+- [PostgresProcessor](#postgres-processor) processes data received from a **PostgreSQL** SELECT.
+- [MssqlProcessor](#mssql-processor) processes data received from a **MSSQL** SELECT.
 - [DynamicProcessor](#dynamic-processor) processes **dynamically generated** data.
 - [TailProcessor](#tail-processor) processes **new lines** added to the file.
 
@@ -503,9 +503,9 @@ Watches for file changes and outputs last part of file as soon as new lines are 
   Name of the file the data came from.
 - **data** `string`
 
-### Database processors <div id='database-processors'/>
+### PostgresProcessor <div id='postgres-processor'/>
 
-Processes `SELECT` query row by row. There are two database processors - `PostgresProcessor` ([usage examples](tests/postgres-source.spec.ts)) and `MssqlProcessor` ([usage examples](tests/mssql-source.spec.ts)). Both of them are having the same options.
+Processes a PostgreSQL `SELECT` query row by row.
 
 #### Options
 
@@ -515,16 +515,32 @@ Processes `SELECT` query row by row. There are two database processors - `Postgr
 - **connection** `object` `required`
   - **user**
   - **password**
-  - **server**\
-    Used with `MssqlProcessor`.
   - **host**
-    Used with `PostgresProcessor`.
   - **port**
   - **database**
-  - **schema**\
-    Currently available only for `PostgresProcessor`.
-  - **driver**\
-    Available only for `MssqlProcessor`. Defines which driver to use - `tedious` (used by default) or `msnodesqlv8`.
+  - **schema**
+
+### MssqlProcessor <div id='mssql-processor'/>
+
+Processes a MSSQL `SELECT` query row by row.
+
+#### Options
+
+- [Processor options](#processor-options)
+- **query** `string` `required`\
+  Query to execute.
+- **connection** `object` `required`
+  - **user**
+  - **password**
+  - **server**
+  - **port**
+  - **database**
+- **driver**\
+    Optional [mssql][mssql-url] TDS driver such as the native [msnodesqlv8][msnodesqlv8-url] driver; defaults to the pure JavaScript [Tedious][tedious-url] driver .
+
+[Usage examples](tests/mssql-source.spec.ts)
+
+Note that `msnodesqlv8` is an optional peer dependency. In previous versions of `bellboy`, a `connection.driver` `string` parameter enabled choosing between the pure Javascript Tedious driver and the native mssqlnodev8  diver. This parameter is ignored in `bellboy` >= v8.0.0.
 
 ### DynamicProcessor <div id='dynamic-processor'/>
 
@@ -636,6 +652,11 @@ Inserts data to MSSQL.
   - **password**
   - **server**
   - **database**
+- **driver**
+
+[Usage examples](tests/mssql-destination.spec.ts)
+
+See [MssqlProcessor](#mssql-processor) for the usage of the `driver` parameter and notes about the optional `msnodesqlv8` dependency.
 
 ## Extendability
 
@@ -699,3 +720,7 @@ class CustomReporter extends bellboy.Reporter {
 ## Testing
 
 Tests can be run by using `docker-compose up --abort-on-container-exit --exit-code-from test --build test` command.
+
+[mssql-url]: https://github.com/tediousjs/node-mssql
+[tedious-url]: https://www.npmjs.com/package/tedious
+[msnodesqlv8-url]: https://www.npmjs.com/package/msnodesqlv8

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Before install, make sure you are using [latest](https://nodejs.org/en/download/
 npm install bellboy
 ```
 
+If you will be using `bellboy` with the native [msnodesqlv8][msnodesqlv8-url] driver, add it as a dependency.
+
+```
+npm install msnodesqlv8
+```
+
 ## Example
 
 This example shows how `bellboy` can extract rows from the [Excel file](#excel-processor), modify it on the fly, load to the [Postgres database](#postgres-destination), move processed file to the other folder and process remaining files.
@@ -536,7 +542,7 @@ Processes a MSSQL `SELECT` query row by row.
   - **port**
   - **database**
   - **driver**\
-      Optional [mssql][mssql-url] TDS driver such as the native [msnodesqlv8][msnodesqlv8-url] driver; defaults to the pure JavaScript [Tedious][tedious-url] driver .
+      Optional [mssql][mssql-url] TDS driver; defaults to the pure JavaScript [Tedious][tedious-url] driver.
 
 #### Usage
 
@@ -555,8 +561,6 @@ const source = new MssqlProcessor({ connection, query: 'select * from orders' })
 ```
 
 In previous versions of `bellboy`, `connection.driver` was a `string` parameter.
-
-Note that `msnodesqlv8` is an optional peer dependency: To use that driver, configure an explicit dependency on the `msnodesqlv8` package.
 
 [More usage examples](tests/mssql-source.spec.ts)
 
@@ -670,7 +674,8 @@ Inserts data to MSSQL.
   - **password**
   - **server**
   - **database**
-  - **driver**
+  - **driver** \
+      Optional [mssql][mssql-url] TDS driver; defaults to the pure JavaScript [Tedious][tedious-url] driver.
 
 #### Usage
 
@@ -687,8 +692,6 @@ const connection: IMssqlDbConnection = {
 };
 const sink = new MssqlDestination({ connection, table: 'orders', batchSize: 1000 });
 ```
-
-See [MssqlProcessor](#mssql-processor) for additional notes about the optional `driver` parameter and the `msnodesqlv8` dependency.
 
 [More usage examples](tests/mssql-destination.spec.ts)
 

--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ Processes a MSSQL `SELECT` query row by row.
   - **driver**\
       Optional [mssql][mssql-url] TDS driver such as the native [msnodesqlv8][msnodesqlv8-url] driver; defaults to the pure JavaScript [Tedious][tedious-url] driver .
 
-#### Usage examples
+#### Usage
 
 Here is an example of how to configure `MssqlProcessor` with a native TDS driver instead of the default pure JavasScript Tedious driver.
 
@@ -672,7 +672,7 @@ Inserts data to MSSQL.
   - **database**
   - **driver**
 
-#### Usage examples
+#### Usage
 
 Here is an example of how to configure `MssqlDestination` with a native TDS driver instead of the default pure JavasScript Tedious driver.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bellboy",
-  "version": "6.6.5",
+  "version": "8.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bellboy",
-      "version": "6.6.5",
+      "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
         "async-mqtt": "^2.2.1",
@@ -41,8 +41,13 @@
         "tslint": "^5.16.0",
         "typescript": "^4.0.2"
       },
-      "optionalDependencies": {
+      "peerDependencies": {
         "msnodesqlv8": "^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "msnodesqlv8": {
+          "optional": true
+        }
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -2283,13 +2288,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -2300,6 +2307,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -2315,6 +2323,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -2940,7 +2949,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/ci-info": {
       "version": "2.0.0",
@@ -3007,6 +3017,7 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3139,7 +3150,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.3",
@@ -3345,6 +3357,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
       "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "mimic-response": "^2.0.0"
       },
@@ -3357,6 +3370,7 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -3468,7 +3482,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/depd": {
       "version": "1.1.2",
@@ -3490,6 +3505,7 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "optional": true,
+      "peer": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -3808,6 +3824,7 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4246,7 +4263,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -4277,6 +4295,7 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -4293,6 +4312,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4302,6 +4322,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -4314,6 +4335,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -4328,6 +4350,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -4396,7 +4419,8 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/glob": {
       "version": "7.1.6",
@@ -4483,7 +4507,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/has-value": {
       "version": "1.0.0",
@@ -4767,7 +4792,8 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -6926,6 +6952,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
       "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -6990,7 +7017,8 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/mqemitter": {
       "version": "4.4.1",
@@ -7095,6 +7123,7 @@
         "linux",
         "darwin"
       ],
+      "peer": true,
       "dependencies": {
         "nan": "^2.14.2",
         "prebuild-install": "^6.1.2"
@@ -7155,7 +7184,8 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/nanoid": {
       "version": "2.1.11",
@@ -7197,7 +7227,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/native-duplexpair": {
       "version": "1.0.0",
@@ -7230,6 +7261,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.26.0.tgz",
       "integrity": "sha512-ag/Vos/mXXpWLLAYWsAoQdgS+gW7IwvgMLOgqopm/DbzAjazLltzgzpVMsFlgmo9TzG5hGXeaBZx2AI731RIsQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "semver": "^5.4.1"
       }
@@ -7381,7 +7413,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
       "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -7421,6 +7454,7 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -7463,6 +7497,7 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7492,6 +7527,7 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7945,6 +7981,7 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.2.tgz",
       "integrity": "sha512-PzYWIKZeP+967WuKYXlTOhYBgGOvTRSfaKI89XnfJ0ansRAH7hDU45X+K+FZeI1Wb/7p/NnuctPH3g0IqKUuSQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
@@ -8156,6 +8193,7 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -8860,13 +8898,15 @@
           "url": "https://feross.org/support"
         }
       ],
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/simple-get": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
       "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
@@ -9340,6 +9380,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9394,6 +9435,7 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -9406,6 +9448,7 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -10243,6 +10286,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
@@ -10252,6 +10296,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
       "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -10261,6 +10306,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -10270,6 +10316,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -10283,6 +10330,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^3.0.0"
       },
@@ -12471,13 +12519,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "optional": true,
+      "peer": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -12488,6 +12538,7 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "optional": true,
+          "peer": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -12503,6 +12554,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
+          "peer": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -13002,7 +13054,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "ci-info": {
       "version": "2.0.0",
@@ -13060,7 +13113,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "codecov": {
       "version": "3.8.0",
@@ -13168,7 +13222,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -13337,6 +13392,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
       "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "mimic-response": "^2.0.0"
       }
@@ -13345,7 +13401,8 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -13429,7 +13486,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "depd": {
       "version": "1.1.2",
@@ -13447,7 +13505,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -13692,7 +13751,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "expect": {
       "version": "26.6.2",
@@ -14050,7 +14110,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -14075,6 +14136,7 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "optional": true,
+      "peer": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -14090,13 +14152,15 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-          "optional": true
+          "optional": true,
+          "peer": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "optional": true,
+          "peer": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -14106,6 +14170,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "optional": true,
+          "peer": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -14117,6 +14182,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "optional": true,
+          "peer": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -14169,7 +14235,8 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "glob": {
       "version": "7.1.6",
@@ -14238,7 +14305,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -14466,7 +14534,8 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -16257,7 +16326,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
       "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -16303,7 +16373,8 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "mqemitter": {
       "version": "4.4.1",
@@ -16389,6 +16460,7 @@
       "resolved": "https://registry.npmjs.org/msnodesqlv8/-/msnodesqlv8-2.1.0.tgz",
       "integrity": "sha512-hl9OXZqd+1l9FFen37YYqFrI2cPDdwZirnreer+iF5/gPkaYUNVKtBkFKubNJDQY9raL5B+8qBjZ+Tl7/ZMBDw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "nan": "^2.14.2",
         "prebuild-install": "^6.1.2"
@@ -16431,7 +16503,8 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "nanoid": {
       "version": "2.1.11",
@@ -16469,7 +16542,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "native-duplexpair": {
       "version": "1.0.0",
@@ -16499,6 +16573,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.26.0.tgz",
       "integrity": "sha512-ag/Vos/mXXpWLLAYWsAoQdgS+gW7IwvgMLOgqopm/DbzAjazLltzgzpVMsFlgmo9TzG5hGXeaBZx2AI731RIsQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "semver": "^5.4.1"
       }
@@ -16619,7 +16694,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
       "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -16653,6 +16729,7 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "optional": true,
+      "peer": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -16688,7 +16765,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "numfmt": {
       "version": "2.1.0",
@@ -16711,7 +16789,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -17064,6 +17143,7 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.2.tgz",
       "integrity": "sha512-PzYWIKZeP+967WuKYXlTOhYBgGOvTRSfaKI89XnfJ0ansRAH7hDU45X+K+FZeI1Wb/7p/NnuctPH3g0IqKUuSQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
@@ -17229,6 +17309,7 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -17807,13 +17888,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "simple-get": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
       "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
@@ -18206,7 +18289,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "stubs": {
       "version": "3.0.0",
@@ -18249,6 +18333,7 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "optional": true,
+      "peer": true,
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -18261,6 +18346,7 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -18926,6 +19012,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       },
@@ -18934,19 +19021,22 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
           "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-          "optional": true
+          "optional": true,
+          "peer": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "optional": true
+          "optional": true,
+          "peer": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "optional": true,
+          "peer": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -18957,6 +19047,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "optional": true,
+          "peer": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -19012,7 +19103,8 @@
     "ws": {
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A=="
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+      "requires": {}
     },
     "xlstream": {
       "version": "2.5.3",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "bellboy",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Highly performant JavaScript data stream ETL engine.",
   "main": "lib/index",
   "types": "lib/index",
   "scripts": {
     "build": "tsc -p .",
     "test": "jest --coverage",
+    "lint": "tslint -c tslint.json -p tsconfig.json",
     "codecov": "codecov"
   },
   "repository": {
@@ -23,8 +24,13 @@
     "url": "https://github.com/Claviz/bellboy/issues"
   },
   "homepage": "https://github.com/Claviz/bellboy#readme",
-  "optionalDependencies": {
+  "peerDependencies": {
     "msnodesqlv8": "^2.1.0"
+  },
+  "peerDependenciesMeta": {
+    "msnodesqlv8": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",

--- a/src/destinations/base/database-destination.ts
+++ b/src/destinations/base/database-destination.ts
@@ -1,15 +1,13 @@
-import { IDatabaseDestinationConfig, IDbConnection } from '../../types';
+import { IDatabaseDestinationConfig } from '../../types';
 import { Destination } from './destination';
 
 export abstract class DatabaseDestination extends Destination {
 
     protected table: string;
-    protected connection: IDbConnection;
 
     constructor(config: IDatabaseDestinationConfig) {
         super(config);
         this.table = config.table;
-        this.connection = config.connection;
     }
 
     async loadBatch(data: any[]) {

--- a/src/destinations/mssql-destination.ts
+++ b/src/destinations/mssql-destination.ts
@@ -1,21 +1,17 @@
-import { IMssqlDestinationConfig, ITdsDriver } from '../types';
+import { IMssqlDestinationConfig, IMssqlDbConnection } from '../types';
 import { DatabaseDestination } from './base/database-destination';
 
 export class MssqlDestination extends DatabaseDestination {
 
-    driver?: ITdsDriver;
+    protected connection: IMssqlDbConnection;
 
     constructor(config: IMssqlDestinationConfig) {
         super(config);
-        if (config.driver) {
-            this.driver = config.driver;
-        } else if (config.connection.driver === 'msnodesqlv8') {
-            console.warn('Falling back to Tedious driver. Add mssql/msnodesqlv8 driver to MssqlDestination config.');
-        }
+        this.connection = config.connection;
     }
 
     async loadBatch(data: any[]) {
-        const sql = this.driver ?? await import('mssql');
+        const sql = this.connection.driver ?? await import('mssql');
         const pool = new sql.ConnectionPool({ ...this.connection } as any);
         const db = await pool.connect();
         const query = await db.request().query(`SELECT TOP(0) * FROM ${this.table}`);

--- a/src/destinations/postgres-destination.ts
+++ b/src/destinations/postgres-destination.ts
@@ -1,4 +1,4 @@
-import { IPostgresDestinationConfig } from '../types';
+import { IPostgresDestinationConfig, IPostgresDbConnection } from '../types';
 import { getDb } from '../utils';
 import { DatabaseDestination } from './base/database-destination';
 
@@ -6,15 +6,17 @@ const pgp = require('pg-promise')();
 
 export class PostgresDestination extends DatabaseDestination {
 
+    protected connection: IPostgresDbConnection;
     protected upsertConstraints: string[] | undefined;
 
     constructor(config: IPostgresDestinationConfig) {
         super(config);
+        this.connection = config.connection;
         this.upsertConstraints = config.upsertConstraints;
     }
 
     async loadBatch(data: any[]) {
-        const dataToUpload: any[] = []
+        const dataToUpload: any[] = [];
         const columnDict: { [key: string]: string } = {};
         const upsertConstraints = this.upsertConstraints;
         let columnIndex = 0;
@@ -29,7 +31,7 @@ export class PostgresDestination extends DatabaseDestination {
             }
             dataToUpload.push(transformed);
         }
-        const columns = Object.keys(columnDict).map(x => ({ name: x, prop: columnDict[x] }))
+        const columns = Object.keys(columnDict).map(x => ({ name: x, prop: columnDict[x] }));
         const cs = new pgp.helpers.ColumnSet(columns, { table: this.table });
         const db = await getDb(this.connection, 'postgres');
         await db.tx(async (t: any) => {

--- a/src/processors/base/database-processor.ts
+++ b/src/processors/base/database-processor.ts
@@ -4,7 +4,6 @@ import { IDatabaseProcessorConfig } from '../../types';
 export abstract class DatabaseProcessor extends Processor {
 
     protected query: string;
-    protected connection: any;
 
     constructor(config: IDatabaseProcessorConfig) {
         super(config);
@@ -12,9 +11,5 @@ export abstract class DatabaseProcessor extends Processor {
             throw new Error(`No query specified.`);
         }
         this.query = config.query;
-        if (!config.connection) {
-            throw new Error(`No connection specified.`);
-        }
-        this.connection = config.connection;
     }
 }

--- a/src/processors/mssql-processor.ts
+++ b/src/processors/mssql-processor.ts
@@ -1,13 +1,18 @@
 import { Readable } from 'stream';
 
-import { IMssqlProcessorConfig, processStream } from '../types';
+import { IMssqlProcessorConfig, ITdsDriver, processStream } from '../types';
 import { closeDbConnection, getDb } from '../utils';
 import { DatabaseProcessor } from './base/database-processor';
 
 export class MssqlProcessor extends DatabaseProcessor {
 
+    driver?: ITdsDriver;
+
     constructor(config: IMssqlProcessorConfig) {
         super(config);
+        if (config.driver) {
+            this.driver = config.driver;
+        }
     }
 
     async process(processStream: processStream) {
@@ -31,7 +36,7 @@ export class MssqlProcessor extends DatabaseProcessor {
             },
         });
         const data: any[] = [];
-        const db = await getDb(this.connection, 'mssql');
+        const db = this.driver ? await getDb(this.connection, 'mssql', this.driver) : await getDb(this.connection, 'mssql');
         const dbRequest = db.request();
         dbRequest.on('error', (err: any) => {
             if (err.code !== 'ECANCEL') {

--- a/src/processors/postgres-processor.ts
+++ b/src/processors/postgres-processor.ts
@@ -1,4 +1,4 @@
-import { IPostgresProcessorConfig, processStream } from '../types';
+import { IPostgresProcessorConfig, IPostgresDbConnection, processStream } from '../types';
 import { getDb } from '../utils';
 import { DatabaseProcessor } from './base/database-processor';
 
@@ -6,8 +6,11 @@ const QueryStream = require('pg-query-stream');
 
 export class PostgresProcessor extends DatabaseProcessor {
 
+    protected connection: IPostgresDbConnection;
+
     constructor(config: IPostgresProcessorConfig) {
         super(config);
+        this.connection = config.connection;
     }
 
     async process(processStream: processStream) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,22 +10,28 @@ export interface AuthorizationRequest {
     prefix?: string;
 }
 
-export type TdsDriverName = 'tedious' | 'msnodesqlv8';
-
-export interface IDbConnection {
+export interface IPostgresDbConnection {
     user?: string;
     password?: string;
-    server?: string;
     host?: string;
     database?: string;
     schema?: string;
-    driver?: TdsDriverName; // this field is deprecated; pass imported driver to getDb, etc
 }
 
 export interface ITdsDriver {
     ConnectionPool: any;
     Transaction: any;
 }
+
+export interface IMssqlDbConnection {
+    user?: string;
+    password?: string;
+    server?: string;
+    database?: string;
+    driver?: ITdsDriver;
+}
+
+export type IDbConnection = IPostgresDbConnection | IMssqlDbConnection;
 
 export interface IReporter {
     report(job: IJob): Promise<void> | void;
@@ -88,15 +94,15 @@ export interface IDestinationConfig {
 
 export interface IDatabaseDestinationConfig extends IDestinationConfig {
     table: string;
-    connection: IDbConnection;
 }
 
 export interface IPostgresDestinationConfig extends IDatabaseDestinationConfig {
+    connection: IPostgresDbConnection;
     upsertConstraints?: string[];
 }
 
 export interface IMssqlDestinationConfig extends IDatabaseDestinationConfig {
-    driver?: ITdsDriver;
+    connection: IMssqlDbConnection;
 }
 
 export interface IHttpDestinationConfig extends IDestinationConfig {
@@ -133,7 +139,6 @@ export interface IDelimitedHttpProcessorConfig extends IHttpProcessorConfig {
 }
 
 export interface IDatabaseProcessorConfig extends IProcessorConfig {
-    connection: any;
     query: string;
 }
 
@@ -149,10 +154,11 @@ export interface IDelimitedProcessorConfig extends IDirectoryProcessorConfig {
 }
 
 export interface IMssqlProcessorConfig extends IDatabaseProcessorConfig {
-    driver?: ITdsDriver;
+    connection: IMssqlDbConnection;
 }
 
 export interface IPostgresProcessorConfig extends IDatabaseProcessorConfig {
+    connection: IPostgresDbConnection;
 }
 
 export interface ITailProcessorConfig extends IDirectoryProcessorConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,8 @@ export interface AuthorizationRequest {
     prefix?: string;
 }
 
+export type TdsDriverName = 'tedious' | 'msnodesqlv8';
+
 export interface IDbConnection {
     user?: string;
     password?: string;
@@ -17,7 +19,12 @@ export interface IDbConnection {
     host?: string;
     database?: string;
     schema?: string;
-    driver?: 'tedious' | 'msnodesqlv8';
+    driver?: TdsDriverName; // this field is deprecated; pass imported driver to getDb, etc
+}
+
+export interface ITdsDriver {
+    ConnectionPool: any;
+    Transaction: any;
 }
 
 export interface IReporter {
@@ -88,7 +95,9 @@ export interface IPostgresDestinationConfig extends IDatabaseDestinationConfig {
     upsertConstraints?: string[];
 }
 
-export interface IMssqlDestinationConfig extends IDatabaseDestinationConfig { }
+export interface IMssqlDestinationConfig extends IDatabaseDestinationConfig {
+    driver?: ITdsDriver;
+}
 
 export interface IHttpDestinationConfig extends IDestinationConfig {
     request: AxiosRequestConfig;
@@ -140,6 +149,7 @@ export interface IDelimitedProcessorConfig extends IDirectoryProcessorConfig {
 }
 
 export interface IMssqlProcessorConfig extends IDatabaseProcessorConfig {
+    driver?: ITdsDriver;
 }
 
 export interface IPostgresProcessorConfig extends IDatabaseProcessorConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface IMssqlDbConnection {
     server?: string;
     database?: string;
     driver?: ITdsDriver;
+    options?: any
 }
 
 export type IDbConnection = IPostgresDbConnection | IMssqlDbConnection;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,48 +1,72 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import { Transform } from 'stream';
 
-import { AuthorizationRequest, DbTypes, IDbConnection, ITdsDriver } from './types';
+import { AuthorizationRequest, DbTypes, IDbConnection, IPostgresDbConnection, IMssqlDbConnection, ITdsDriver } from './types';
 
 const cachedDbConnections = new Map<string, { db: any, close: any }>();
-export async function getDb(databaseConfig: IDbConnection, dbType: DbTypes, tdsDriver?: ITdsDriver) {
-    const dbKey = JSON.stringify(databaseConfig);
-    if (cachedDbConnections.has(dbKey)) {
-        const dbConnection = cachedDbConnections.get(dbKey);
-        if (dbConnection) {
-            return dbConnection.db;
-        }
+
+function getCachedDbConnection(databaseConfig: IDbConnection) {
+    const dbKey = getDbKey(databaseConfig);
+    return cachedDbConnections.get(dbKey);
+}
+
+function getDbKey(databaseConfig: IPostgresDbConnection | IMssqlDbConnection) {
+    if ('driver' in databaseConfig) {
+        const configWithoutDriver = { ...databaseConfig };
+        delete configWithoutDriver.driver;
+        return JSON.stringify(configWithoutDriver);
+    }
+    return JSON.stringify(databaseConfig);
+}
+
+function setCachedDbConnection(databaseConfig: IDbConnection, db: any, close: any) {
+    const dbKey = getDbKey(databaseConfig);
+    cachedDbConnections.set(dbKey, { db, close });
+}
+
+function unsetCachedDbConnection(databaseConfig: IDbConnection) {
+    const dbKey = getDbKey(databaseConfig);
+    cachedDbConnections.delete(dbKey);
+}
+
+export async function getDb(databaseConfig: IDbConnection, dbType: DbTypes) {
+    const dbConnection = getCachedDbConnection(databaseConfig);
+    if (dbConnection) {
+        return dbConnection.db;
     }
     if (dbType === 'mssql') {
-        if (!tdsDriver && databaseConfig.driver === 'msnodesqlv8') {
-            console.warn('Falling back to Tedious driver. Pass mssql/msnodesqlv8 driver as a third argument to getDb function.');
-        }
-        const sql = tdsDriver ?? await import('mssql');
-        const pool = new sql.ConnectionPool({ ...databaseConfig } as any);
-        const db = await pool.connect();
-        cachedDbConnections.set(dbKey, {
-            db,
-            close: pool.close.bind(pool),
-        });
-        return db;
+        return await getMssqlDb(databaseConfig);
     } else {
-        const pgp = require('pg-promise')({ schema: databaseConfig.schema || 'public', });
-        const db = pgp(databaseConfig);
-        cachedDbConnections.set(dbKey, {
-            db,
-            close: pgp.end,
-        });
-        return db;
+        return getPostgresDb(databaseConfig);
     }
-};
+}
+
+async function getMssqlDb(databaseConfig: IMssqlDbConnection) {
+    const driver = databaseConfig.driver ?? await import('mssql');
+    const pool = getMssqlDbPool(driver, databaseConfig);
+    const db = await pool.connect();
+    setCachedDbConnection(databaseConfig, db, pool.close.bind(pool));
+    return db;
+}
+
+function getMssqlDbPool(driver: ITdsDriver, databaseConfig: IMssqlDbConnection) {
+    const poolConfig = { ...databaseConfig };
+    delete poolConfig.driver;
+    return new driver.ConnectionPool({ ...databaseConfig } as any);
+}
+
+function getPostgresDb(databaseConfig: IPostgresDbConnection) {
+    const pgp = require('pg-promise')({ schema: databaseConfig.schema || 'public' });
+    const db = pgp(databaseConfig);
+    setCachedDbConnection(databaseConfig, db, pgp.end);
+    return db;
+}
 
 export async function closeDbConnection(databaseConfig: IDbConnection) {
-    const dbKey = JSON.stringify(databaseConfig);
-    if (cachedDbConnections.has(dbKey)) {
-        const dbConnection = cachedDbConnections.get(dbKey);
-        if (dbConnection) {
-            await dbConnection.close();
-            cachedDbConnections.delete(dbKey);
-        }
+    const dbConnection = getCachedDbConnection(databaseConfig);
+    if (dbConnection) {
+        await dbConnection.close();
+        unsetCachedDbConnection(databaseConfig);
     }
 }
 
@@ -56,7 +80,7 @@ export function getValueFromJSONChunk() {
             callback();
         }
     });
-};
+}
 
 export function removeCircularReferencesFromChunk() {
     return new Transform({
@@ -79,7 +103,7 @@ export function removeCircularReferencesFromChunk() {
             callback();
         }
     });
-};
+}
 
 export function getDelimitedGenerator({
     readStream,
@@ -96,7 +120,7 @@ export function getDelimitedGenerator({
             }
             return { header, arr: record, obj, row: raw };
         }
-    }
+    };
     const generator = async function* () {
         for await (const row of readStream) {
             const result = processRow(row);
@@ -104,7 +128,7 @@ export function getDelimitedGenerator({
                 yield result;
             }
         }
-    }
+    };
 
     return generator;
 }

--- a/tests/mssql-destination.spec.ts
+++ b/tests/mssql-destination.spec.ts
@@ -8,7 +8,6 @@ const connection: any = {
     password: 'Passw0rd*',
     server: 'mssql',
     database: 'tempdb',
-    driver: null,
     options: {
         trustServerCertificate: true,
     }
@@ -17,15 +16,14 @@ const connection: any = {
 
 describe.each(['tedious', 'msnodesqlv8'])('different drivers', (driverName) => {
 
-    let nativeDriver: ITdsDriver | undefined;
     beforeAll(async () => {
         if (driverName === 'msnodesqlv8') {
-            nativeDriver = await import('mssql/msnodesqlv8');
+            connection.driver = await import('mssql/msnodesqlv8');
         }
     });
 
     beforeEach(async () => {
-        db = await utils.getDb(connection, 'mssql', nativeDriver);
+        db = await utils.getDb(connection, 'mssql');
         await db.query(`DROP TABLE IF EXISTS test_sources`);
         await db.query(`CREATE TABLE test_sources
         (
@@ -50,9 +48,6 @@ describe.each(['tedious', 'msnodesqlv8'])('different drivers', (driverName) => {
             table: 'test_sources',
             batchSize: 1,
         };
-        if (nativeDriver) {
-            destinationConfig.driver = nativeDriver;
-        }
         const destination = new MssqlDestination(destinationConfig);
         const job = new Job(processor, [destination]);
         await job.run();

--- a/tests/mssql-destination.spec.ts
+++ b/tests/mssql-destination.spec.ts
@@ -1,9 +1,9 @@
 import { Job, DynamicProcessor, MssqlDestination } from '../src';
-import { ITdsDriver, IMssqlDestinationConfig } from '../src/types';
+import { IMssqlDbConnection } from '../src/types';
 import * as utils from '../src/utils';
 
 let db: any = null;
-const connection: any = {
+const connection: IMssqlDbConnection = {
     user: 'sa',
     password: 'Passw0rd*',
     server: 'mssql',
@@ -43,12 +43,11 @@ describe.each(['tedious', 'msnodesqlv8'])('different drivers', (driverName) => {
                 }
             },
         });
-        const destinationConfig: IMssqlDestinationConfig = {
+        const destination = new MssqlDestination({
             connection,
             table: 'test_sources',
             batchSize: 1,
-        };
-        const destination = new MssqlDestination(destinationConfig);
+        });
         const job = new Job(processor, [destination]);
         await job.run();
         const res = await db.query(`select * from test_sources`);

--- a/tests/mssql-source.spec.ts
+++ b/tests/mssql-source.spec.ts
@@ -16,12 +16,11 @@ const connection: any = {
 describe.each(['tedious', 'msnodesqlv8'])('different drivers', (driverName) => {
 
     beforeEach(async () => {
-        let nativeDriver;
         if (driverName === 'msnodesqlv8') {
-            nativeDriver = await import('mssql/msnodesqlv8');
+            connection.driver = await import('mssql/msnodesqlv8');
         }
 
-        db = await utils.getDb(connection, 'mssql', nativeDriver);
+        db = await utils.getDb(connection, 'mssql');
         await db.query(`DROP TABLE IF EXISTS test`);
         await db.query(`CREATE TABLE test
         (

--- a/tests/mssql-source.spec.ts
+++ b/tests/mssql-source.spec.ts
@@ -13,11 +13,15 @@ const connection: any = {
     }
 };
 
-describe.each(['tedious', 'msnodesqlv8'])('different drivers', (driver) => {
+describe.each(['tedious', 'msnodesqlv8'])('different drivers', (driverName) => {
 
     beforeEach(async () => {
-        connection.driver = driver;
-        db = await utils.getDb(connection, 'mssql');
+        let nativeDriver;
+        if (driverName === 'msnodesqlv8') {
+            nativeDriver = await import('mssql/msnodesqlv8');
+        }
+
+        db = await utils.getDb(connection, 'mssql', nativeDriver);
         await db.query(`DROP TABLE IF EXISTS test`);
         await db.query(`CREATE TABLE test
         (
@@ -29,7 +33,7 @@ describe.each(['tedious', 'msnodesqlv8'])('different drivers', (driver) => {
         await utils.closeDbConnection(connection);
     })
 
-    it(`gets data from mssql using ${driver} driver`, async () => {
+    it(`gets data from mssql using ${driverName} driver`, async () => {
         await db.query(`INSERT INTO test (id) values (123)`);
         const destination = new CustomDestination({
             batchSize: 1,
@@ -45,7 +49,7 @@ describe.each(['tedious', 'msnodesqlv8'])('different drivers', (driver) => {
         }]);
     });
 
-    it(`respects rowLimit using ${driver} driver`, async () => {
+    it(`respects rowLimit using ${driverName} driver`, async () => {
         await db.query(`INSERT INTO test (id) values (1), (2), (3), (4)`);
         const destination = new CustomDestination();
         const processor = new MssqlProcessor({

--- a/tests/mssql-source.spec.ts
+++ b/tests/mssql-source.spec.ts
@@ -1,9 +1,10 @@
 import { Job, MssqlProcessor } from '../src';
+import { IMssqlDbConnection } from '../src/types';
 import * as utils from '../src/utils';
 import { CustomDestination } from './helpers';
 
 let db: any = null;
-const connection: any = {
+const connection: IMssqlDbConnection = {
     user: 'sa',
     password: 'Passw0rd*',
     server: 'mssql',

--- a/tests/postgres-source.spec.ts
+++ b/tests/postgres-source.spec.ts
@@ -15,8 +15,8 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-    await db.query(`DROP TABLE IF EXISTS test`);
-    await db.query(`CREATE TABLE test
+    await db.query(`DROP TABLE IF EXISTS test_sources`);
+    await db.query(`CREATE TABLE test_sources
     (
         id integer
     )`);
@@ -27,13 +27,13 @@ afterAll(async () => {
 })
 
 it('gets data from postgres', async () => {
-    await db.query(`INSERT INTO test (id) values (123)`);
+    await db.query(`INSERT INTO test_sources (id) values (123)`);
     const destination = new CustomDestination({
         batchSize: 1,
     });
     const processor = new PostgresProcessor({
         connection,
-        query: `select id from test`,
+        query: `select id from test_sources`,
     });
     const job = new Job(processor, [destination]);
     await job.run();
@@ -43,14 +43,14 @@ it('gets data from postgres', async () => {
 });
 
 it('waits for data to be loaded before ending processing', async () => {
-    await db.query(`INSERT INTO test (id) values (123)`);
+    await db.query(`INSERT INTO test_sources (id) values (123)`);
     const destination = new CustomTimeoutDestination({
         batchSize: 100,
         timeout: 1000,
     });
     const processor = new PostgresProcessor({
         connection,
-        query: `select id from test`,
+        query: `select id from test_sources`,
     });
     const job = new Job(processor, [destination]);
     await job.run();
@@ -60,11 +60,11 @@ it('waits for data to be loaded before ending processing', async () => {
 });
 
 it('respects rowLimit', async () => {
-    await db.query(`INSERT INTO test (id) values (1), (2), (3), (4)`);
+    await db.query(`INSERT INTO test_sources (id) values (1), (2), (3), (4)`);
     const destination = new CustomDestination();
     const processor = new PostgresProcessor({
         connection,
-        query: `select id from test`,
+        query: `select id from test_sources`,
         rowLimit: 3,
     });
     const job = new Job(processor, [destination]);

--- a/tslint.json
+++ b/tslint.json
@@ -8,6 +8,8 @@
         "member-access": false,
         "no-console": false,
         "object-literal-sort-keys": false,
-        "quotemark": false
+        "ordered-imports": false,
+        "quotemark": false,
+        "trailing-comma": false
     }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -3,9 +3,11 @@
     "extends": [
         "tslint:recommended"
     ],
-    "jsRules": {},
     "rules": {
+        "max-line-length": false,
+        "member-access": false,
+        "no-console": false,
+        "object-literal-sort-keys": false,
         "quotemark": false
-    },
-    "rulesDirectory": [],
+    }
 }


### PR DESCRIPTION
The purpose of this PR is to remove `msnodesqlv8` as a mandatory dependency, since it requires building a native package with external dependencies.

Due to the fact that (non-peer) optional dependencies are automatically installed as well as the static analysis that TypeScript performs for dynamic `import()`, it's not possible to make this change entirely backwards compatible, so this PR proposes a major version bump. Users of the `msnodesqlv8` driver will need to add that package as an explicit dependency and modify the configuration of `MssqlProcessor` and `MssqlDestination` instances to inject an `mssql/msnodesqlv8` driver.

MSSQL tests sometimes failed due to `jest` running the specifications in parallel: To fix this, I changed the table name in one of the specifications. I did not see this happen with PostgreSQL tests, but I made the same change in the PostgreSQL tests, just to be safe.

`tslint` indicates a number of linting issues. I tried not to introduce any new ones, but I didn't fix existing issues because I didn't want de-linting changes to obscure the intent of this PR. I silenced a few of the more innocuous warnings.

Please let me know if you have questions, and thanks again for this elegant library.

Commit summary:

- `msnodesqlv8` now an optional peer dependency
- MSSQL `driver` argument takes imported TDS driver instead of driver name
- varied table name for integration tests to avoid race conditions
- bumping version to 8.0.0